### PR TITLE
Fix syntax highlighting for if-goto

### DIFF
--- a/syntax/hack_vm.vim
+++ b/syntax/hack_vm.vim
@@ -8,6 +8,7 @@ if version < 600
 endif
 
 setl iskeyword+=.,:
+setl iskeyword+=-
 
 syn keyword hackVmMathLogicOp add sub neg eq gt lt or not
 syn keyword hackVmMemoryOp push pop


### PR DESCRIPTION
This fixes the syntax highlighting for hack-vm files. For whatever reason this errored out in vim when I tried putting it on a the same iskeyword line above so I put it on a new line and it works great.